### PR TITLE
fix(zephyr): install rust for user

### DIFF
--- a/zephyr/Dockerfile
+++ b/zephyr/Dockerfile
@@ -4,12 +4,6 @@ ARG REPOSITORY_URL="https://github.com/zephyrproject-rtos/zephyr"
 RUN apt-get update && apt-get install -y \
   curl \
   tree
-  
-RUN apt-get remove -y \
-  cargo \
-  rustc
-  
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 COPY west-update-with-retry /usr/local/bin
 RUN chmod +x /usr/local/bin/west-update-with-retry
@@ -19,6 +13,9 @@ WORKDIR /workdir
 RUN chown -R user:user /workdir
 USER user
 # cmake package is registered under user: user (see zephyrprojectrtos/ci dockerfile)
+
+# install rust under user
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 # Pull from main to get latest updates
 RUN west init -m $REPOSITORY_URL --mr main


### PR DESCRIPTION
In the current Dockerfile rust is installed for the root user instead of the user "user" that runs the build.